### PR TITLE
project: update all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,21 +21,25 @@ serde_json = "^1.0"
 
 [dependencies.futures]
 optional = true
-version = "~0.1"
+version = "0.1"
+
+[dependencies.http]
+optional = true
+version = "0.1"
 
 [dependencies.hyper]
 optional = true
-version = "~0.11"
+version = "0.12"
 
 [dependencies.reqwest]
 optional = true
-version = "~0.8"
+version = "0.9"
 
 [dev-dependencies]
-hyper-tls = "~0.1"
-tokio-core = "~0.1"
+hyper-rustls = "0.16"
+tokio = "0.1"
 
 [features]
 default = ["reqwest-support"]
-hyper-support = ["futures", "hyper"]
+hyper-support = ["futures", "http", "hyper"]
 reqwest-support = ["reqwest"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # kitsu.rs
 
 An unofficial Rust library acting as a wrapper around the [Kitsu] API, offering
-implementations for both asynchronous hyper (v0.11) and synchronous reqwest
-(v0.8).
+implementations for both asynchronous hyper (v0.12) and synchronous reqwest
+(v0.9).
 
 **note:** The library supports retrieval from the API, but does not currently
 support authenticated requests.

--- a/examples/01_reqwest/Cargo.toml
+++ b/examples/01_reqwest/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["my name <my@email.address>"]
 
 [dependencies]
-reqwest = "0.8.0"
+reqwest = "0.9"
 
 [dependencies.kitsu]
 features = ["reqwest-support"]

--- a/examples/02_hyper/Cargo.toml
+++ b/examples/02_hyper/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 authors = ["my name <my@email.address>"]
 
 [dependencies]
-futures = "~0.1"
-hyper = "~0.11"
-hyper-tls = "~0.1"
-tokio-core = "0.1.10"
+futures = "0.1"
+hyper = "0.12"
+hyper-rustls = "0.16"
+tokio = "0.1"
 
 [dependencies.kitsu]
 default-features = false

--- a/examples/02_hyper/src/main.rs
+++ b/examples/02_hyper/src/main.rs
@@ -1,16 +1,15 @@
 extern crate futures;
 extern crate hyper;
-extern crate hyper_tls;
+extern crate hyper_rustls;
 extern crate kitsu;
-extern crate tokio_core;
+extern crate tokio;
 
 use futures::Future;
 use futures::stream::Stream;
 use hyper::Client;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use kitsu::KitsuHyperRequester;
 use std::io::{self, Write};
-use tokio_core::reactor::Core;
 
 fn main() {
     // Read an anime name to search for from the users input.
@@ -20,14 +19,8 @@ fn main() {
     io::stdin().read_line(&mut input).expect("Error reading input");
     let input_trimmed = input.trim();
 
-    // Create the core and client which will be uesd to search.
-    let mut core = Core::new().expect("Error creating reactor core");
-
-    let connector = HttpsConnector::new(1, &core.handle())
-        .expect("Error creating connector");
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     // Search for the anime and return the response.
     let runner = client.search_anime(|f| f.filter("text", input_trimmed))
@@ -40,5 +33,5 @@ fn main() {
             println!("\n\nDone")
         });
 
-    core.run(runner).expect("Error running core");
+    tokio::run(runner);
 }

--- a/src/bridge/hyper.rs
+++ b/src/bridge/hyper.rs
@@ -8,9 +8,14 @@
 
 use futures::future::{self, Future};
 use futures::Stream;
-use hyper::client::{Client as HyperClient, Connect};
-use hyper::error::Error as HyperError;
-use hyper::Uri;
+use http::uri::Uri;
+use hyper::{
+    body::Body,
+    client::{
+        connect::Connect,
+        Client as HyperClient,
+    }
+};
 use serde_json;
 use std::str::FromStr;
 use ::builder::Search;
@@ -47,22 +52,17 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
-    /// use kitsu::KitsuHyperRequester;
+    /// use hyper_rustls::HttpsConnector;
     /// use hyper::Client;
+    /// use kitsu::KitsuHyperRequester;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
-    /// let mut core = Core::new()?;
-    ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let anime_id = 1;
     ///
@@ -77,18 +77,18 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn get_anime(&self, id: u64)
-        -> Box<Future<Item = Response<Anime>, Error = Error>>;
+        -> Box<Future<Item = Response<Anime>, Error = Error> + Send>;
 
     /// Gets a character using its id.
     fn get_character(&self, id: u64)
-        -> Box<Future<Item = Response<Character>, Error = Error>>;
+        -> Box<Future<Item = Response<Character>, Error = Error> + Send>;
 
     /// Gets a manga using its id.
     ///
@@ -98,22 +98,19 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
+    /// use hyper_rustls::HttpsConnector;
     /// use kitsu::KitsuHyperRequester;
     /// use hyper::Client;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
     /// let mut core = Core::new()?;
     ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let manga_id = 1;
     ///
@@ -128,14 +125,14 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn get_manga(&self, id: u64)
-        -> Box<Future<Item = Response<Manga>, Error = Error>>;
+        -> Box<Future<Item = Response<Manga>, Error = Error> + Send>;
 
     // Gets a producer using their id.
     ///
@@ -145,22 +142,19 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
+    /// use hyper_rustls::HttpsConnector;
     /// use kitsu::KitsuHyperRequester;
     /// use hyper::Client;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
     /// let mut core = Core::new()?;
     ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let producer_id = 1;
     ///
@@ -175,14 +169,14 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn get_producer(&self, id: u64)
-        -> Box<Future<Item = Response<Producer>, Error = Error>>;
+        -> Box<Future<Item = Response<Producer>, Error = Error> + Send>;
 
     /// Gets a user using their id.
     ///
@@ -192,22 +186,19 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
+    /// use hyper_rustls::HttpsConnector;
     /// use kitsu::KitsuHyperRequester;
     /// use hyper::Client;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
     /// let mut core = Core::new()?;
     ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let user_id = 1;
     ///
@@ -222,14 +213,14 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn get_user(&self, id: u64)
-        -> Box<Future<Item = Response<User>, Error = Error>>;
+        -> Box<Future<Item = Response<User>, Error = Error> + Send>;
 
     /// Searches for an anime using the passed [Search] builder.
     ///
@@ -239,22 +230,19 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
+    /// use hyper_rustls::HttpsConnector;
     /// use kitsu::KitsuHyperRequester;
     /// use hyper::Client;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
     /// let mut core = Core::new()?;
     ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let anime_name = "Beyond the Boundary";
     ///
@@ -269,18 +257,18 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn search_anime<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<Anime>>, Error = Error>>;
+        -> Box<Future<Item = Response<Vec<Anime>>, Error = Error> + Send>;
 
     /// Searches for a character using the passed search builder.
     fn search_characters<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<Character>>, Error = Error>>;
+        -> Box<Future<Item = Response<Vec<Character>>, Error = Error> + Send>;
 
     /// Searches for a manga using the passed [Search] builder.
     ///
@@ -290,22 +278,19 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
+    /// use hyper_rustls::HttpsConnector;
     /// use kitsu::KitsuHyperRequester;
     /// use hyper::Client;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
     /// let mut core = Core::new()?;
     ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let manga_name = "Orange";
     ///
@@ -320,14 +305,14 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn search_manga<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<Manga>>, Error = Error>>;
+        -> Box<Future<Item = Response<Vec<Manga>>, Error = Error> + Send>;
 
     /// Searches for a user using the passed [`Search`] builder.
     ///
@@ -337,22 +322,19 @@ pub trait KitsuRequester {
     ///
     /// ```rust,ignore
     /// extern crate hyper;
-    /// extern crate hyper_tls;
+    /// extern crate hyper_rustls;
     /// extern crate kitsu;
-    /// extern crate tokio_core;
+    /// extern crate tokio;
     ///
-    /// use hyper_tls::HttpsConnector;
+    /// use hyper_rustls::HttpsConnector;
     /// use kitsu::KitsuHyperRequester;
     /// use hyper::Client;
     /// use std::env;
-    /// use tokio_core::reactor::Core;
     ///
     /// let mut core = Core::new()?;
     ///
-    /// let connector = HttpsConnector::new(1, &core.handle())?;
-    /// let client = Client::configure()
-    ///     .connector(connector)
-    ///     .build(&core.handle());
+    /// let connector = HttpsConnector::new(1);
+    /// let client = Client::builder().build(connector);
     ///
     /// let user_name = "Bob";
     ///
@@ -367,82 +349,81 @@ pub trait KitsuRequester {
     ///         println!("Error with the request: {:?}", why);
     ///     });
     ///
-    /// core.run(runner)?;
+    /// tokio::run(runner);
     /// ```
     ///
     /// [`Search`]: ../builder/struct.Search.html
     ///
     // Note: This doc example can not be tested due to the reliance on
-    // tokio_core. Instead, this is taken from example `02_hyper` and should
+    // tokio. Instead, this is taken from example `02_hyper` and should
     // roughly match it to ensure accuracy.
     fn search_users<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<User>>, Error = Error>>;
+        -> Box<Future<Item = Response<Vec<User>>, Error = Error> + Send>;
 }
 
-impl<B, C: Connect> KitsuRequester for HyperClient<C, B>
-    where B: Stream<Error = HyperError> + 'static, B::Item: AsRef<[u8]> {
+impl<C: Connect + Send + 'static> KitsuRequester for HyperClient<C, Body> {
     fn get_anime(&self, id: u64)
-        -> Box<Future<Item = Response<Anime>, Error = Error>> {
+        -> Box<Future<Item = Response<Anime>, Error = Error> + Send> {
         let url = format!("{}/anime/{}", API_URL, id);
         let c = &url;
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn get_character(&self, id: u64)
-        -> Box<Future<Item = Response<Character>, Error = Error>> {
+        -> Box<Future<Item = Response<Character>, Error = Error> + Send> {
         let url = format!("{}/characters/{}", API_URL, id);
         let c = &url;
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn get_manga(&self, id: u64)
-        -> Box<Future<Item = Response<Manga>, Error = Error>> {
+        -> Box<Future<Item = Response<Manga>, Error = Error> + Send> {
         let url = format!("{}/manga/{}", API_URL, id);
         let c = &url;
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn get_producer(&self, id: u64)
-        -> Box<Future<Item = Response<Producer>, Error = Error>> {
+        -> Box<Future<Item = Response<Producer>, Error = Error> + Send> {
         let url = format!("{}/producer/{}", API_URL, id);
         let c = &url;
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn get_user(&self, id: u64)
-        -> Box<Future<Item = Response<User>, Error = Error>> {
+        -> Box<Future<Item = Response<User>, Error = Error> + Send> {
         let url = format!("{}/users/{}", API_URL, id);
         let c = &url;
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn search_anime<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<Anime>>, Error = Error>> {
+        -> Box<Future<Item = Response<Vec<Anime>>, Error = Error> + Send> {
         let params = f(Search::default()).0;
 
         let url = format!("{}/anime?{}", API_URL, params);
@@ -450,13 +431,13 @@ impl<B, C: Connect> KitsuRequester for HyperClient<C, B>
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn search_characters<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<Character>>, Error = Error>> {
+        -> Box<Future<Item = Response<Vec<Character>>, Error = Error> + Send> {
         let params = f(Search::default()).0;
 
         let url = format!("{}/characters?{}", API_URL, params);
@@ -464,13 +445,13 @@ impl<B, C: Connect> KitsuRequester for HyperClient<C, B>
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn search_manga<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<Manga>>, Error = Error>> {
+        -> Box<Future<Item = Response<Vec<Manga>>, Error = Error> + Send> {
         let params = f(Search::default()).0;
 
         let url = format!("{}/manga?{}", API_URL, params);
@@ -478,13 +459,13 @@ impl<B, C: Connect> KitsuRequester for HyperClient<C, B>
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }
 
     fn search_users<F: FnOnce(Search) -> Search>(&self, f: F)
-        -> Box<Future<Item = Response<Vec<User>>, Error = Error>> {
+        -> Box<Future<Item = Response<Vec<User>>, Error = Error> + Send> {
         let params = f(Search::default()).0;
 
         let url = format!("{}/users?{}", API_URL, params);
@@ -492,7 +473,7 @@ impl<B, C: Connect> KitsuRequester for HyperClient<C, B>
         let uri = try_uri!(c);
 
         Box::new(self.get(uri)
-            .and_then(|res| res.body().concat2())
+            .and_then(|res| res.into_body().concat2())
             .map_err(From::from)
             .and_then(|body| serde_json::from_slice(&body).map_err(From::from)))
     }

--- a/src/bridge/reqwest.rs
+++ b/src/bridge/reqwest.rs
@@ -404,31 +404,31 @@ impl KitsuRequester for ReqwestClient {
     fn get_anime(&self, id: u64) -> Result<Response<Anime>> {
         let uri = Url::parse(&format!("{}/anime/{}", API_URL, id.to_string()))?;
 
-        handle_request::<Response<Anime>>(&mut self.get(uri))
+        handle_request::<Response<Anime>>(self.get(uri))
     }
 
     fn get_character(&self, id: u64) -> Result<Response<Character>> {
         let uri = Url::parse(&format!("{}/characters/{}", API_URL, id.to_string()))?;
 
-        handle_request::<Response<Character>>(&mut self.get(uri))
+        handle_request::<Response<Character>>(self.get(uri))
     }
 
     fn get_manga(&self, id: u64) -> Result<Response<Manga>> {
         let uri = Url::parse(&format!("{}/manga/{}", API_URL, id.to_string()))?;
 
-        handle_request::<Response<Manga>>(&mut self.get(uri))
+        handle_request::<Response<Manga>>(self.get(uri))
     }
 
     fn get_user(&self, id: u64) -> Result<Response<User>> {
         let uri = Url::parse(&format!("{}/users/{}", API_URL, id.to_string()))?;
 
-        handle_request::<Response<User>>(&mut self.get(uri))
+        handle_request::<Response<User>>(self.get(uri))
     }
 
     fn get_producer(&self, id: u64) -> Result<Response<Producer>> {
         let uri = Url::parse(&format!("{}/producers/{}", API_URL, id.to_string()))?;
 
-        handle_request::<Response<Producer>>(&mut self.get(uri))
+        handle_request::<Response<Producer>>(self.get(uri))
     }
 
     fn search_anime<F: FnOnce(Search) -> Search>(&self, f: F) ->
@@ -436,7 +436,7 @@ impl KitsuRequester for ReqwestClient {
         let params = f(Search::default()).0;
         let uri = Url::parse(&format!("{}/anime?{}", API_URL, params))?;
 
-        handle_request::<Response<Vec<Anime>>>(&mut self.get(uri))
+        handle_request::<Response<Vec<Anime>>>(self.get(uri))
     }
 
     fn search_characters<F: FnOnce(Search) -> Search>(&self, f: F) ->
@@ -444,7 +444,7 @@ impl KitsuRequester for ReqwestClient {
         let params = f(Search::default()).0;
         let uri = Url::parse(&format!("{}/characters?{}", API_URL, params))?;
 
-        handle_request::<Response<Vec<Character>>>(&mut self.get(uri))
+        handle_request::<Response<Vec<Character>>>(self.get(uri))
     }
 
     fn search_manga<F: FnOnce(Search) -> Search>(&self, f: F) ->
@@ -452,7 +452,7 @@ impl KitsuRequester for ReqwestClient {
         let params = f(Search::default()).0;
         let uri = Url::parse(&format!("{}/manga?{}", API_URL, params))?;
 
-        handle_request::<Response<Vec<Manga>>>(&mut self.get(uri))
+        handle_request::<Response<Vec<Manga>>>(self.get(uri))
     }
 
     fn search_users<F: FnOnce(Search) -> Search>(&self, f: F) ->
@@ -460,19 +460,19 @@ impl KitsuRequester for ReqwestClient {
         let params = f(Search::default()).0;
         let uri = Url::parse(&format!("{}/users?{}", API_URL, params))?;
 
-        handle_request::<Response<Vec<User>>>(&mut self.get(uri))
+        handle_request::<Response<Vec<User>>>(self.get(uri))
     }
 }
 
-fn handle_request<T: DeserializeOwned>(request: &mut RequestBuilder) -> Result<T> {
+fn handle_request<T: DeserializeOwned>(request: RequestBuilder) -> Result<T> {
     let response = request.send()?;
 
     match response.status() {
-        StatusCode::Ok => {},
-        StatusCode::BadRequest => {
+        StatusCode::OK => {},
+        StatusCode::BAD_REQUEST => {
             return Err(Error::ReqwestBad(Box::new(response)));
         },
-        StatusCode::Unauthorized => {
+        StatusCode::UNAUTHORIZED => {
             return Err(Error::ReqwestUnauthorized(Box::new(response)));
         },
         _ => return Err(Error::ReqwestInvalid(Box::new(response))),

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,9 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::result::Result as StdResult;
 
 #[cfg(feature = "hyper")]
-use hyper::error::{Error as HyperError, UriError};
+use http::uri::InvalidUri;
+#[cfg(feature = "hyper")]
+use hyper::error::Error as HyperError;
 #[cfg(feature = "reqwest")]
 use reqwest::{
     Error as ReqwestError,
@@ -48,7 +50,7 @@ pub enum Error {
     /// An error when building a request's URI from the `hyper` crate when it is
     /// enabled.
     #[cfg(feature = "hyper")]
-    Uri(UriError),
+    Uri(InvalidUri),
 }
 
 #[cfg(feature = "hyper")]
@@ -79,8 +81,8 @@ impl From<ReqwestUrlError> for Error {
 }
 
 #[cfg(feature = "hyper")]
-impl From<UriError> for Error {
-    fn from(err: UriError) -> Error {
+impl From<InvalidUri> for Error {
+    fn from(err: InvalidUri) -> Error {
         Error::Uri(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! # kitsu.rs
 //!
 //! An unofficial Rust library acting as a wrapper around the [Kitsu] API,
-//! offering implementations for both asynchronous hyper (v0.11) and synchronous
-//! reqwest (v0.8).
+//! offering implementations for both asynchronous hyper (v0.12) and synchronous
+//! reqwest (v0.9).
 //!
 //! **note:** The library supports retrieval from the API, but does not currently
 //! support authenticated requests.
@@ -18,7 +18,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! kitsu = "0.1"
+//! kitsu = "0.2"
 //! ```
 //!
 //! To enable both `hyper` and `reqwest` support:
@@ -105,6 +105,8 @@ extern crate serde_json;
 
 #[cfg(feature = "hyper")]
 extern crate futures;
+#[cfg(feature = "hyper")]
+extern crate http;
 #[cfg(feature = "hyper")]
 extern crate hyper;
 #[cfg(feature = "reqwest")]

--- a/tests/test_hyper_support.rs
+++ b/tests/test_hyper_support.rs
@@ -2,102 +2,77 @@
 
 extern crate futures;
 extern crate hyper;
-extern crate hyper_tls;
+extern crate hyper_rustls;
 extern crate kitsu;
-extern crate tokio_core;
+extern crate tokio;
 
 use futures::Future;
 use hyper::Client;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use kitsu::KitsuHyperRequester;
-use tokio_core::reactor::Core;
 
 #[ignore]
 #[test]
 fn test_get_anime() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.get_anime(1).map(|_| ()).map_err(|_| ());
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_get_character() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.get_character(1).map(|_| ()).map_err(|why| {
         panic!("{:?}", why);
     });
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_get_manga() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.get_manga(1).map(|_| ()).map_err(|_| ());
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_get_producer() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.get_producer(1).map(|_| ()).map_err(|_| ());
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_get_user() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.get_user(1).map(|_| ()).map_err(|_| ());
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_search_anime() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.search_anime(|f| f.filter("text", "non non biyori"))
         .map(|_| ())
@@ -105,37 +80,29 @@ fn test_search_anime() {
             panic!("{:?}", why);
         });
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_search_manga() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.search_manga(|f| f.filter("text", "orange"))
         .map(|_| ()).map_err(|_| ());
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }
 
 #[ignore]
 #[test]
 fn test_search_users() {
-    let mut core = Core::new().unwrap();
-
-    let connector = HttpsConnector::new(1, &core.handle()).unwrap();
-    let client = Client::configure()
-        .connector(connector)
-        .build(&core.handle());
+    let connector = HttpsConnector::new(1);
+    let client = Client::builder().build(connector);
 
     let runner = client.search_users(|f| f.filter("name", "vikhyat"))
         .map(|_| ()).map_err(|_| ());
 
-    core.run(runner).unwrap();
+    tokio::run(runner);
 }


### PR DESCRIPTION
Update all dependencies, updating 'hyper' from 0.11 to 0.12 and
'reqwest' from 0.8 to 0.9. 'http' is now an optional dependency compiled
in with 'hyper' support.

The development dependencies 'hyper_tls' and 'tokio_core' have been
removed in favour of 'hyper_rustls' and 'tokio'.

@Mishio595 can you let me know if this works when you have a chance

Signed-off-by: Zeyla Hellyer <zeyla@hellyer.dev>